### PR TITLE
Add device metadata for DHT22 sensors

### DIFF
--- a/enviro-b2.yaml
+++ b/enviro-b2.yaml
@@ -100,11 +100,17 @@ sensor:
     pin: GPIO26
     temperature:
       name: "DHT22_Temperature"
+      device_class: temperature
+      state_class: measurement
+      unit_of_measurement: "°C"
       id: temp
       filters:
         - lambda: return x + ${temperature_calibration};
     humidity:
       name: "DHT22_Humidity"
+      device_class: humidity
+      state_class: measurement
+      unit_of_measurement: "%"
       id: humidity
       filters:
         - lambda: return x + ${humidity_calibration};


### PR DESCRIPTION
## Summary
- specify device class, state class, and units for DHT22 temperature and humidity sensors

## Testing
- `pre-commit run --files enviro-b2.yaml` *(command not found)*
- `esphome config enviro-b2.yaml` *(Invalid key format, missing secret)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e3c9463083279fc9a66acd919912